### PR TITLE
Deconflict Privileged and CAPs

### DIFF
--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -303,6 +303,7 @@ module Beaker
                 'PortBindings' => {
                   '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
                 },
+                'Privileged' => true,
                 'PublishAllPorts' => true,
                 'RestartPolicy' => {
                   'Name' => 'always'
@@ -337,6 +338,7 @@ module Beaker
                   '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
                 },
                 'PublishAllPorts' => true,
+                'Privileged' => true,
                 'RestartPolicy' => {
                   'Name' => 'always'
                 }
@@ -367,6 +369,7 @@ module Beaker
                   '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
                 },
                 'PublishAllPorts' => true,
+                'Privileged' => true,
                 'RestartPolicy' => {
                   'Name' => 'always'
                 }
@@ -424,6 +427,7 @@ module Beaker
                   '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
                 },
                 'PublishAllPorts' => true,
+                'Privileged' => true,
                 'RestartPolicy' => {
                   'Name' => 'always'
                 }


### PR DESCRIPTION
Privileged cannot be set if the user selects individual CAPs to set.
However, to preserve legacy runner compatibiliy, privileged should be
set if neither is set.