### PR TITLE
Update to Check Rootless

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,5 +1,4 @@
 group :acceptance_testing do
   # Needed for podman testing
-  gem "docker-api", '~> 2.1'
   gem "beaker-rspec"
 end

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,4 +1,3 @@
 group :acceptance_testing do
-  # Needed for podman testing
   gem "beaker-rspec"
 end

--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'docker-api', '< 3.0.0'
+  s.add_runtime_dependency 'docker-api', ['>= 2.1.0', '< 3.0.0']
 
 end
 

--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'docker-api', ['>= 2.1.0', '< 3.0.0']
+  s.add_runtime_dependency 'docker-api', '~> 2.1'
 
 end
 

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -259,10 +259,11 @@ module Beaker
             container = ::Docker::Container.create(container_opts)
 
             ssh_info = get_ssh_connection_info(container)
-            if ssh_info[:ip] == '127.0.0.1' && (ssh_info[:port].to_i < 1024) && (Process.uid != 0)
-              @logger.debug("#{host} was given a port less than 1024 but you are not running as root, retrying")
+            if ::Docker.rootless? && ssh_info[:ip] == '127.0.0.1' && (ssh_info[:port].to_i < 1024)
+              @logger.debug("#{host} was given a port less than 1024 but you are connecting to a rootless instance, retrying")
 
               container.delete
+              container = nil
 
               retries+=1
               next

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -105,6 +105,10 @@ module Beaker
 
     let (:version) { {"ApiVersion"=>"1.18", "Arch"=>"amd64", "GitCommit"=>"4749651", "GoVersion"=>"go1.4.2", "KernelVersion"=>"3.16.0-37-generic", "Os"=>"linux", "Version"=>"1.6.0"} }
 
+    before :each do
+      allow(::Docker).to receive(:rootless?).and_return(true)
+    end
+
     context 'with connection failure' do
       describe '#initialize' do
         before :each do


### PR DESCRIPTION
Fixed the 'rootless' port check to use the new `::Docker.rootless?`
instead of checking the current UID since that was prone to false
positives.