### PR TITLE
Fix docker usage to use correct port and IP address on local docker

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -152,11 +152,12 @@ module Beaker
         else
           port22 = network_settings.dig('Ports','22/tcp')
           ip = port22[0]["HostIp"] if port22
+          port = port22[0]['HostPort'] if port22
         end
       end
 
       if host_config['NetworkMode'] != 'slirp4netns' && network_settings['IPAddress'] && !network_settings['IPAddress'].empty?
-        ip = network_settings['IPAddress']
+        ip = network_settings['IPAddress'] if ip.nil?
       else
         port22 = network_settings.dig('Ports','22/tcp')
         port = port22[0]['HostPort'] if port22

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -536,8 +536,8 @@ module Beaker
               ENV['DOCKER_HOST'] = nil
               docker.provision
 
-              expect( hosts[0]['ip'] ).to be === '192.0.2.1'
-              expect( hosts[0]['port'] ).to be ===  '22'
+              expect( hosts[0]['ip'] ).to be === '127.0.1.1'
+              expect( hosts[0]['port'] ).to be ===  8022
             end
           end
 


### PR DESCRIPTION
This fixes #43 .  Output from local docker run of beaker using this patch:

```
centos-7 15:07:30$ cat /etc/resolv.conf
  Attempting ssh connection to 127.0.0.1, user: root, opts: {:password=>"root", :port=>"5484", :forward_agent=>false, :auth_methods=>["password", "publickey", "hostbased", "keyboard-interactive"]}
```

Before this patch my local executions using beaker were trying to connect to the container IP and port 22 both of which won't work.