### PR TITLE
Force Container Removal

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -262,7 +262,7 @@ module Beaker
             if ::Docker.rootless? && ssh_info[:ip] == '127.0.0.1' && (ssh_info[:port].to_i < 1024)
               @logger.debug("#{host} was given a port less than 1024 but you are connecting to a rootless instance, retrying")
 
-              container.delete
+              container.delete(force: true)
               container = nil
 
               retries+=1
@@ -288,7 +288,7 @@ module Beaker
         begin
           container.stats
         rescue StandardError => e
-          container.delete
+          container.delete(force: true)
           raise "Container '#{container.id}' in a bad state: #{e}"
         end
 
@@ -403,7 +403,7 @@ module Beaker
             end
             @logger.debug("delete container #{container.id}")
             begin
-              container.delete
+              container.delete(force: true)
             rescue Excon::Errors::ClientError => e
               @logger.warn("deletion of container #{container.id} failed: #{e.response.body}")
             end


### PR DESCRIPTION
Added the `force` option whenever a container is to be deleted so that
random potential errors don't fail the run.