### PR TITLE
Treat Fedora 22+ and EL8 the same

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -348,7 +348,7 @@ module Beaker
         container.exec(%w(apt-get update))
         container.exec(%w(apt-get install -y openssh-server openssh-client))
         container.exec(%w(sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/*))
-      when /fedora-(2[2-9])/
+      when /el-8/, /fedora-(2[2-9]|3[0-9])/
         container.exec(%w(dnf clean all))
         container.exec(%w(dnf install -y sudo openssh-server openssh-clients))
         container.exec(%w(ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key))
@@ -485,15 +485,7 @@ module Beaker
           RUN apt-get update
           RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES.join(' ')}
           EOF
-      when /fedora-(2[2-9])/
-        dockerfile += <<~EOF
-          RUN dnf clean all
-          RUN dnf install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
-          RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-          RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
-          RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/*
-          EOF
-      when /el-8/
+      when /el-8/, /fedora-(2[2-9]|3)/
         dockerfile += <<~EOF
           RUN dnf clean all
           RUN dnf install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::RHEL8_PACKAGES.join(' ')}

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -697,7 +697,7 @@ module Beaker
           expect( dockerfile ).to be =~ /RUN zypper -n in openssh/
         end
 
-        (22..29).to_a.each do | fedora_release |
+        (22..39).to_a.each do | fedora_release |
           it "should use dnf on fedora #{fedora_release}" do
             FakeFS.deactivate!
             dockerfile = docker.send(:dockerfile_for, {


### PR DESCRIPTION
Fedora has defaulted to chrony since Fedora 14. It also uses DNF by default since Fedora 22. Both of these are also true for EL8. While this doesn't use chrony on Fedora 14-21, it doesn't really matter since those are EOL for a long time now.