### PR TITLE
Fix SSH port binding

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -156,6 +156,9 @@ module Beaker
 
           # Host to Container
           port22 = network_settings.dig('PortBindings','22/tcp')
+          if port22.nil? && network_settings.key?('Ports')
+            port22 = network_settings.dig('Ports','22/tcp')
+          end
           ip = port22[0]['HostIp'] if port22
           port = port22[0]['HostPort'] if port22
 

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -68,7 +68,7 @@ module Beaker
           'Ports' => {
             '22/tcp' => [
               {
-                'HostIp' => '127.0.1.1',
+                'HostIp' => '0.0.0.0',
                 'HostPort' => 8022,
               },
             ],
@@ -491,7 +491,7 @@ module Beaker
               ENV['DOCKER_HOST'] = nil
               docker.provision
 
-              expect( hosts[0]['ip'] ).to be === '192.0.2.1'
+              expect( hosts[0]['ip'] ).to be === '127.0.0.1'
               expect( hosts[0]['port'] ).to be ===  8022
             end
 
@@ -507,7 +507,7 @@ module Beaker
               ENV['DOCKER_HOST'] = nil
               docker.provision
 
-              expect( hosts[0]['ip'] ).to be === '192.0.2.1'
+              expect( hosts[0]['ip'] ).to be === '127.0.0.1'
               expect( hosts[0]['port'] ).to be === 8022
               expect( hosts[0]['ssh'][:password] ).to be ===  'root'
               expect( hosts[0]['ssh'][:port] ).to be ===  8022
@@ -537,8 +537,8 @@ module Beaker
               ENV['DOCKER_HOST'] = nil
               docker.provision
 
-              expect( hosts[0]['ip'] ).to be === '192.0.2.1'
-              expect( hosts[0]['port'] ).to be ===  22
+              expect( hosts[0]['ip'] ).to be === '127.0.0.1'
+              expect( hosts[0]['port'] ).to be ===  8022
             end
           end
 


### PR DESCRIPTION
Fixes #52 

From what I can gather the key lookup of `PortBinding` in network settings is wrong, but rather than assume it never exists, I kept behavior but if `Ports` exists, which is used in unit tests and what my Docker daemon exposes, then use that instead.

So unit tests look like what I see on my Docker daemon:

```json
        "NetworkSettings": {
            "Bridge": "",
            "SandboxID": "5b3ed04c8e2e65b854bd9a05cf2053e0ae4e932e3e43811197a10255e646ad40",
            "HairpinMode": false,
            "LinkLocalIPv6Address": "",
            "LinkLocalIPv6PrefixLen": 0,
            "Ports": {
                "22/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "4584"
                    }
                ]
            },
            "SandboxKey": "/var/run/docker/netns/5b3ed04c8e2e",
            "SecondaryIPAddresses": null,
            "SecondaryIPv6Addresses": null,
            "EndpointID": "ee4961d5a4a1b37548b6c24b3b1be1ee0473a4d9057b0502c6ebe4ebf2129d1c",
            "Gateway": "172.17.0.1",
            "GlobalIPv6Address": "",
            "GlobalIPv6PrefixLen": 0,
            "IPAddress": "172.17.0.6",
            "IPPrefixLen": 16,
            "IPv6Gateway": "",
            "MacAddress": "02:42:ac:11:00:06",
            "Networks": {
                "bridge": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": null,
                    "NetworkID": "c8a38b79ba988bf1d1301ca810fdceae30636924d57466403047607d14466dce",
                    "EndpointID": "ee4961d5a4a1b37548b6c24b3b1be1ee0473a4d9057b0502c6ebe4ebf2129d1c",
                    "Gateway": "172.17.0.1",
                    "IPAddress": "172.17.0.6",
                    "IPPrefixLen": 16,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "02:42:ac:11:00:06",
                    "DriverOpts": null
                }
            }
        }
    }
```

I also updated unit tests to test using `0.0.0.0` since that's what the code sets when setting up the SSH port binding.