### PR TITLE
Add Docker hostfile parameter docker_image_first_commands

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -23,13 +23,22 @@ The base image to use for the container is named by the image key.
       type: foss
 
 ### Docker hosts file, with image modification ###
-You can specify extra commands to be executed in order to modify the image with the `docker_image_commands` key.
+You can specify extra commands to be executed in order to modify the image with the keys `docker_image_commands` and
+`docker_image_first_commands`.
+
+`docker_image_commands` is executed after initial setup. `docker_image_first_commands` is executed before any other
+commands and can be used eg. to configure a proxy.
 
     HOSTS:
       ubuntu-12-10:
         platform: ubuntu-12.10-x64
         image: ubuntu:12.10
         hypervisor: docker
+        docker_image_first_commands:
+          - echo 'Acquire::http::Proxy "http://proxy.example.com:3128";'> /etc/apt/apt.conf.d/01proxy
+          - echo "export http_proxy=http://proxy.example.com:3128"> /etc/profile.d/proxy.sh
+          - echo "export https_proxy=http://proxy.example.com:3128">> /etc/profile.d/proxy.sh
+          - echo "export no_proxy=127.0.0.1,::1">> /etc/profile.d/proxy.sh
         docker_image_commands:
           - 'apt-get install -y myapp'
           - 'myapp --setup'
@@ -53,7 +62,7 @@ Instead of using ssh as the CMD for a container, beaker will use the entrypoint 
 
     HOSTS:
       puppetserver:
-        platform: ubuntu-1604-x86_64 
+        platform: ubuntu-1604-x86_64
         hypervisor: docker
         image: puppet/puppetserver-standalone:6.0.1
         use_image_entry_point: true

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -516,6 +516,11 @@ module Beaker
         ENV container docker
       EOF
 
+      # Commands before any other commands. Can be used for eg. proxy configuration
+      dockerfile += (host['docker_image_first_commands'] || []).map { |command|
+        "RUN #{command}\n"
+      }.join('')
+
       # additional options to specify to the sshd
       # may vary by platform
       sshd_options = ''

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -692,6 +692,23 @@ module Beaker
           end
         end
 
+        it 'should add docker_image_first_commands as RUN statements' do
+          FakeFS.deactivate!
+          platforms.each do |platform|
+            dockerfile = docker.send(:dockerfile_for, {
+              'platform' => platform,
+              'image' => 'foobar',
+              'docker_image_first_commands' => [
+                'special one',
+                'special two',
+                'special three',
+              ]
+            })
+
+            expect( dockerfile ).to be =~ /RUN special one\nRUN special two\nRUN special three/
+          end
+        end
+
         it 'should add docker_image_commands as RUN statements' do
           FakeFS.deactivate!
           platforms.each do |platform|


### PR DESCRIPTION
Adds a Docker hostfile parameter `docker_image_first_commands` which allows inserting RUN commands at the very top of the Dockerfile. This allows proxy configuration for apt/yum/dnf.

`docker_image_commands` does not work for this as it's commands are inserted too late to configure proxy for all package manager commands. 

Thank you for considering. I am behind a proxy at my company and this makes testing a bit easier for me as we don't currently have a direct-to-internet environment for development.