### PR TITLE
Generate a ssh port from 1025..9999 range

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -78,7 +78,7 @@ module Beaker
         'Hostname' => host.name,
         'HostConfig' => {
           'PortBindings' => {
-            '22/tcp' => [{ 'HostPort' => rand.to_s[2..5], 'HostIp' => '0.0.0.0'}]
+            '22/tcp' => [{ 'HostPort' => rand(1025..9999).to_s, 'HostIp' => '0.0.0.0'}]
           },
           'PublishAllPorts' => true,
           'RestartPolicy' => {


### PR DESCRIPTION
It was possible to generate a ssh port <= 1024 before. This is ok for rootful containers but it doesn't work for rootless. That causes another re-provisioning attempt until the port above 1024 is generated. With this change the generated port is always within 1025..9999 inclusive range.