### PR TITLE
Fix rubocop-related issues (part 1)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+tab_width = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 .bundle
 .vendor
 _vendor
+vendor
 tmp/
 doc
 # JetBrains IDEA

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,15 @@ AllCops:
   Exclude:
   - vendor/**/*
 
-# Disable temporarily
+Naming/FileName:
+  Description: Gemfile.local is well-known file name
+  Exclude:
+  - Gemfile.local
 Style/HashSyntax:
+  Description: Disable temporarily (FIXME)
+  EnforcedStyle: ruby19
   Enabled: false
+
+# Style enforcements
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ AllCops:
   Exclude:
   - vendor/**/*
 
+Metrics:
+  Description: Metrics cops are rarely useful
+  Enabled: false
+
 Naming/FileName:
   Description: Gemfile.local is well-known file name
   Exclude:
@@ -42,3 +46,7 @@ Naming/FileName:
 # Style enforcements
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma
+Style/IfUnlessModifier:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,11 @@ Style/HashSyntax:
   EnforcedStyle: ruby19
   Enabled: false
 
+Naming/FileName:
+  Description: Some files violates the snake_case convention
+  Exclude:
+    - 'lib/beaker-docker.rb'
+
 # Style enforcements
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,4 +41,4 @@ Naming/FileName:
 
 # Style enforcements
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -423,7 +423,6 @@ Style/Documentation:
 # SupportedStyles: always, always_true, never
 Style/FrozenStringLiteralComment:
   Exclude:
-    - '.simplecov'
     - 'acceptance/tests/00_default_spec.rb'
     - 'bin/beaker-docker'
     - 'lib/beaker-docker/version.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -198,12 +198,6 @@ Layout/SpaceInsideParens:
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Lint/DeprecatedClassMethods:
-  Exclude:
-    - 'Gemfile'
-
-# Offense count: 1
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
 Lint/DuplicateBranch:
   Exclude:
@@ -430,11 +424,6 @@ Rake/Desc:
   Exclude:
     - 'Rakefile'
 
-# Offense count: 1
-Security/Eval:
-  Exclude:
-    - 'Gemfile'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
@@ -502,7 +491,6 @@ Style/ExpandPathArguments:
 Style/FrozenStringLiteralComment:
   Exclude:
     - '.simplecov'
-    - 'Gemfile'
     - 'Rakefile'
     - 'acceptance/tests/00_default_spec.rb'
     - 'beaker-docker.gemspec'
@@ -529,7 +517,6 @@ Style/IfInsideElse:
 # Cop supports --auto-correct.
 Style/IfUnlessModifier:
   Exclude:
-    - 'Gemfile'
     - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -282,17 +282,6 @@ RSpec/ContextWording:
   Exclude:
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: IgnoredMetadata.
-RSpec/DescribeClass:
-  Exclude:
-    - 'acceptance/tests/00_default_spec.rb'
-
-# Offense count: 1
-RSpec/EmptyExampleGroup:
-  Exclude:
-    - 'acceptance/tests/00_default_spec.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 RSpec/EmptyLineAfterFinalLet:
@@ -423,7 +412,6 @@ Style/Documentation:
 # SupportedStyles: always, always_true, never
 Style/FrozenStringLiteralComment:
   Exclude:
-    - 'acceptance/tests/00_default_spec.rb'
     - 'bin/beaker-docker'
     - 'lib/beaker-docker/version.rb'
     - 'lib/beaker/hypervisor/docker.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,17 +34,10 @@ Layout/BlockEndNewline:
   Exclude:
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/CommentIndentation:
-  Exclude:
-    - 'Rakefile'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterGuardClause:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
 
 # Offense count: 5
@@ -60,7 +53,6 @@ Layout/EmptyLines:
 # SupportedStyles: empty_lines, no_empty_lines
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
-    - 'Rakefile'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
 # Offense count: 1
@@ -84,12 +76,6 @@ Layout/ExtraSpacing:
 # SupportedStyles: special_inside_parentheses, consistent, align_braces
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/HeredocIndentation:
-  Exclude:
-    - 'Rakefile'
 
 # Offense count: 5
 # Cop supports --auto-correct.
@@ -186,7 +172,6 @@ Layout/SpaceInsideHashLiteralBraces:
 # SupportedStyles: space, no_space
 Layout/SpaceInsideParens:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
@@ -221,12 +206,6 @@ Lint/ParenthesesAsGroupedExpression:
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
 # Offense count: 1
-# Configuration parameters: AllowComments, AllowNil.
-Lint/SuppressedException:
-  Exclude:
-    - 'Rakefile'
-
-# Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods, IgnoreNotImplementedMethods.
 Lint/UnusedMethodArgument:
@@ -236,7 +215,6 @@ Lint/UnusedMethodArgument:
 # Offense count: 6
 Lint/UselessAssignment:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
 
 # Offense count: 8
@@ -279,13 +257,6 @@ Metrics/ModuleLength:
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:
   Max: 39
-
-# Offense count: 1
-# Configuration parameters: ForbiddenDelimiters.
-# ForbiddenDelimiters: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))
-Naming/HeredocDelimiterNaming:
-  Exclude:
-    - 'Rakefile'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -411,12 +382,6 @@ RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Rake/Desc:
-  Exclude:
-    - 'Rakefile'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
@@ -451,12 +416,6 @@ Style/ConditionalAssignment:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Style/Dir:
-  Exclude:
-    - 'Rakefile'
-
 # Offense count: 1
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
@@ -472,7 +431,6 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Exclude:
     - '.simplecov'
-    - 'Rakefile'
     - 'acceptance/tests/00_default_spec.rb'
     - 'bin/beaker-docker'
     - 'lib/beaker-docker/version.rb'
@@ -497,17 +455,8 @@ Style/IfInsideElse:
 # Cop supports --auto-correct.
 Style/IfUnlessModifier:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: nonzero?
-Style/IfWithBooleanLiteralBranches:
-  Exclude:
-    - 'Rakefile'
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -521,7 +470,6 @@ Style/LineEndConcatenation:
 # SupportedStyles: literals, strict
 Style/MutableConstant:
   Exclude:
-    - 'Rakefile'
     - 'bin/beaker-docker'
     - 'lib/beaker-docker/version.rb'
 
@@ -552,7 +500,6 @@ Style/ParenthesesAroundCondition:
 # Configuration parameters: PreferredDelimiters.
 Style/PercentLiteralDelimiters:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
 
 # Offense count: 2
@@ -568,7 +515,6 @@ Style/PreferredHashMethods:
 # Configuration parameters: Methods.
 Style/RedundantArgument:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
 
 # Offense count: 1
@@ -594,7 +540,6 @@ Style/RedundantRegexpEscape:
 # Configuration parameters: AllowMultipleReturnValues.
 Style/RedundantReturn:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
 
 # Offense count: 1
@@ -604,14 +549,6 @@ Style/RedundantReturn:
 Style/RegexpLiteral:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: only_raise, only_fail, semantic
-Style/SignalException:
-  Exclude:
-    - 'Rakefile'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -626,7 +563,6 @@ Style/StringConcatenation:
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Exclude:
-    - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,13 +21,6 @@ Layout/ArgumentAlignment:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth.
-Layout/AssignmentIndentation:
-  Exclude:
-    - 'bin/beaker-docker'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/BlockEndNewline:
@@ -44,7 +37,6 @@ Layout/EmptyLineAfterGuardClause:
 # Cop supports --auto-correct.
 Layout/EmptyLines:
   Exclude:
-    - 'bin/beaker-docker'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
 # Offense count: 5
@@ -412,7 +404,6 @@ Style/Documentation:
 # SupportedStyles: always, always_true, never
 Style/FrozenStringLiteralComment:
   Exclude:
-    - 'bin/beaker-docker'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
@@ -441,14 +432,6 @@ Style/IfUnlessModifier:
 Style/LineEndConcatenation:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: literals, strict
-Style/MutableConstant:
-  Exclude:
-    - 'bin/beaker-docker'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -154,7 +154,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Layout/SpaceInsideBlockBraces:
   Exclude:
     - 'spec/beaker/hypervisor/docker_spec.rb'
-    - 'spec/spec_helper.rb'
 
 # Offense count: 25
 # Cop supports --auto-correct.
@@ -191,12 +190,6 @@ Lint/EmptyBlock:
 Lint/MissingSuper:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Lint/NonDeterministicRequireOrder:
-  Exclude:
-    - 'spec/spec_helper.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -436,7 +429,6 @@ Style/FrozenStringLiteralComment:
     - 'lib/beaker-docker/version.rb'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
-    - 'spec/spec_helper.rb'
 
 # Offense count: 2
 # Configuration parameters: MinBodyLength.
@@ -555,7 +547,6 @@ Style/RegexpLiteral:
 Style/StringConcatenation:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
-    - 'spec/spec_helper.rb'
 
 # Offense count: 64
 # Cop supports --auto-correct.
@@ -581,7 +572,6 @@ Style/TernaryParentheses:
 Style/TrailingCommaInArrayLiteral:
   Exclude:
     - 'spec/beaker/hypervisor/docker_spec.rb'
-    - 'spec/spec_helper.rb'
 
 # Offense count: 25
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,12 +47,6 @@ Layout/EmptyLineAfterGuardClause:
     - 'Rakefile'
     - 'lib/beaker/hypervisor/docker.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterMagicComment:
-  Exclude:
-    - 'beaker-docker.gemspec'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 Layout/EmptyLines:
@@ -155,7 +149,6 @@ Layout/SpaceAroundOperators:
 # SupportedStylesForEmptyBraces: space, no_space
 Layout/SpaceBeforeBlockBraces:
   Exclude:
-    - 'beaker-docker.gemspec'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
 # Offense count: 2
@@ -472,18 +465,6 @@ Style/Documentation:
     - 'test/**/*'
     - 'lib/beaker/hypervisor/docker.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/Encoding:
-  Exclude:
-    - 'beaker-docker.gemspec'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ExpandPathArguments:
-  Exclude:
-    - 'beaker-docker.gemspec'
-
 # Offense count: 10
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
@@ -493,7 +474,6 @@ Style/FrozenStringLiteralComment:
     - '.simplecov'
     - 'Rakefile'
     - 'acceptance/tests/00_default_spec.rb'
-    - 'beaker-docker.gemspec'
     - 'bin/beaker-docker'
     - 'lib/beaker-docker/version.rb'
     - 'lib/beaker/hypervisor/docker.rb'
@@ -573,7 +553,6 @@ Style/ParenthesesAroundCondition:
 Style/PercentLiteralDelimiters:
   Exclude:
     - 'Rakefile'
-    - 'beaker-docker.gemspec'
     - 'lib/beaker/hypervisor/docker.rb'
 
 # Offense count: 2
@@ -603,12 +582,6 @@ Style/RedundantCondition:
 Style/RedundantException:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/RedundantPercentQ:
-  Exclude:
-    - 'beaker-docker.gemspec'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -654,7 +627,6 @@ Style/StringConcatenation:
 Style/StringLiterals:
   Exclude:
     - 'Rakefile'
-    - 'beaker-docker.gemspec'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -413,7 +413,6 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'bin/beaker-docker'
-    - 'lib/beaker-docker/version.rb'
     - 'lib/beaker/hypervisor/docker.rb'
     - 'spec/beaker/hypervisor/docker_spec.rb'
 
@@ -450,7 +449,6 @@ Style/LineEndConcatenation:
 Style/MutableConstant:
   Exclude:
     - 'bin/beaker-docker'
-    - 'lib/beaker-docker/version.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.configure do
   add_filter 'spec/'
   add_filter 'vendor/'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
 if File.exist? "#{__FILE__}.local"
-  eval(File.read("#{__FILE__}.local"), binding)
+  eval(File.read("#{__FILE__}.local"), binding) # rubocop:disable Security/Eval
 end
 
 group :coverage, optional: ENV['COVERAGE'] != 'yes' do

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 group :acceptance_testing do
-  gem "beaker-rspec"
+  gem 'beaker-rspec'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,24 @@
+# frozen_string_literal: true
+
 require 'rspec/core/rake_task'
 
 namespace :lint do
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new(:rubocop) do |task|
     # Use Rubocop's Github Actions formatter
-    if ENV['GITHUB_ACTIONS'] == 'true'
-      task.formatters << 'github'
-    end
+    task.formatters << 'github' if ENV['GITHUB_ACTIONS'] == 'true'
   end
 end
 
 namespace :test do
   namespace :spec do
-    desc "Run spec tests"
+    desc 'Run spec tests'
     RSpec::Core::RakeTask.new(:run) do |t|
       t.rspec_opts = ['--color', '--format documentation']
       t.pattern = 'spec/'
     end
 
-    desc "Run spec tests with coverage"
+    desc 'Run spec tests with coverage'
     RSpec::Core::RakeTask.new(:coverage) do |t|
       ENV['BEAKER_DOCKER_COVERAGE'] = 'y'
       t.rspec_opts = ['--color', '--format documentation']
@@ -27,26 +27,25 @@ namespace :test do
   end
 
   namespace :acceptance do
-    desc <<-EOS
-A quick acceptance test, named because it has no pre-suites to run
-    EOS
+    desc 'A quick acceptance test, named because it has no pre-suites to run'
     task :quick do
+      ## setup & load_path of beaker's acceptance base and lib directory
+      ## see below for the reason why it's commented out atm
+      # beaker_gem_spec = Gem::Specification.find_by_name('beaker')
+      # beaker_gem_dir = beaker_gem_spec.gem_dir
+      # beaker_test_base_dir = File.join(beaker_gem_dir, 'acceptance/tests/base')
+      # load_path_option = File.join(beaker_gem_dir, 'acceptance/lib')
 
-      # setup & load_path of beaker's acceptance base and lib directory
-      beaker_gem_spec = Gem::Specification.find_by_name('beaker')
-      beaker_gem_dir = beaker_gem_spec.gem_dir
-      beaker_test_base_dir = File.join(beaker_gem_dir, 'acceptance/tests/base')
-      load_path_option = File.join(beaker_gem_dir, 'acceptance/lib')
-
-      ENV['BEAKER_setfile'] = 'acceptance/config/nodes/hosts.yaml' unless ENV.key?('BEAKER_setfile')
-      sh("beaker",
-          # We can't run these tests until the rsync support in the main
-          # beaker/host.rb is updated to work with passwords.
-          # "--tests", beaker_test_base_dir,
-          # "--load-path", load_path_option,
-         "--tests", 'acceptance/tests/',
-         "--log-level", "debug",
-         "--debug")
+      ENV['BEAKER_setfile'] = 'acceptance/config/nodes/hosts.yaml'
+      sh('beaker',
+         '--hosts', 'acceptance/config/nodes/hosts.yaml',
+         ## We can't run these tests until the rsync support in the main
+         ## beaker/host.rb is updated to work with passwords.
+         # '--tests', beaker_test_base_dir,
+         # '--load-path', load_path_option,
+         '--tests', 'acceptance/tests/',
+         '--log-level', 'debug',
+         '--debug')
     end
   end
 end
@@ -54,21 +53,22 @@ end
 # namespace-named default tasks.
 # these are the default tasks invoked when only the namespace is referenced.
 # they're needed because `task :default` in those blocks doesn't work as expected.
-task 'test:spec' => 'test:spec:run'
-task 'test:acceptance' => 'test:acceptance:quick'
+task 'test:spec': %i[test:spec:run]
+task 'test:acceptance': %i[test:acceptance:quick]
 
 # global defaults
-task :lint => %i[lint:rubocop]
-task :test => 'test:spec'
-task :default => :test
+task lint: %i[lint:rubocop]
+task test: %i[test:spec]
+task default: %i[test]
 
 begin
   require 'rubygems'
   require 'github_changelog_generator/task'
 rescue LoadError
+  # Do nothing if no required gem installed
 else
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.exclude_labels = %w{duplicate question invalid wontfix wont-fix skip-changelog}
+    config.exclude_labels = %w[duplicate question invalid wontfix wont-fix skip-changelog]
     config.user = 'voxpupuli'
     config.project = 'beaker-docker'
     gem_version = Gem::Specification.load("#{config.project}.gemspec").version

--- a/acceptance/tests/00_default_spec.rb
+++ b/acceptance/tests/00_default_spec.rb
@@ -1,10 +1,11 @@
-require 'beaker'
-require 'beaker-rspec'
+# frozen_string_literal: true
 
-RSpec.describe 'it can connect' do
+require 'beaker'
+
+test_name 'Ensure docker container is accessible' do
   hosts.each do |host|
-    context "on #{host}" do
-      on(host, 'ls /tmp')
+    step "on #{host}" do
+      on(host, 'true')
     end
   end
 end

--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -1,26 +1,27 @@
-# -*- encoding: utf-8 -*-
-$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'beaker-docker/version'
 
 Gem::Specification.new do |s|
-  s.name        = "beaker-docker"
+  s.name        = 'beaker-docker'
   s.version     = BeakerDocker::VERSION
   s.authors     = [
-    "Vox Pupuli",
-    "Rishi Javia",
-    "Kevin Imber",
-    "Tony Vu",
+    'Vox Pupuli',
+    'Rishi Javia',
+    'Kevin Imber',
+    'Tony Vu',
   ]
-  s.email       = ["voxpupuli@groups.io"]
-  s.homepage    = "https://github.com/voxpupuli/beaker-docker"
-  s.summary     = %q{Beaker DSL Extension Helpers!}
-  s.description = %q{For use for the Beaker acceptance testing tool}
+  s.email       = ['voxpupuli@groups.io']
+  s.homepage    = 'https://github.com/voxpupuli/beaker-docker'
+  s.summary     = 'Docker hypervisor for Beaker acceptance testing framework'
+  s.description = 'Allows running Beaker tests using Docker'
   s.license     = 'Apache-2.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.4', '< 4'
 

--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
     "Vox Pupuli",
     "Rishi Javia",
     "Kevin Imber",
-    "Tony Vu"
+    "Tony Vu",
   ]
   s.email       = ["voxpupuli@groups.io"]
   s.homepage    = "https://github.com/voxpupuli/beaker-docker"

--- a/bin/beaker-docker
+++ b/bin/beaker-docker
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'rubygems' unless defined?(Gem)
 require 'beaker-docker'
 
-VERSION_STRING =
-"
+VERSION_STRING = <<'VER'
                                  _ .--.
                                 ( `    )
         beaker-docker         .-'      `--,
@@ -14,19 +14,17 @@ VERSION_STRING =
               ;|  _|  _|  _|  '-'__,--'`--'
               | _|  _|  _|  _| |
           _   ||  _|  _|  _|  _| %s
-        _( `--.\\_|  _|  _|  _|/
+        _( `--.\_|  _|  _|  _|/
      .-'       )--,|  _|  _|.`
     (__, (_      ) )_|  _| /
-      `-.__.\\ _,--'\\|__|__/
+      `-.__.\ _,--'\|__|__/
                     ;____;
-                     \\YT/
+                     \YT/
                       ||
-                     |\"\"|
+                     |""|
                      '=='
-"
+VER
 
-
-
-puts BeakerDocker::VERSION
+puts VERSION_STRING % BeakerDocker::VERSION
 
 exit 0

--- a/lib/beaker-docker.rb
+++ b/lib/beaker-docker.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/lib/beaker-docker/version.rb
+++ b/lib/beaker-docker/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BeakerDocker
   VERSION = '1.4.0'
 end

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -615,7 +615,7 @@ module Beaker
                       '-e', 's/^#?UseDNS .*/UseDNS no/',
                       # Unbreak users with a bunch of SSH keys loaded in their keyring.
                       '-e', 's/^#?MaxAuthTries.*/MaxAuthTries 1000/',
-                      '/etc/ssh/sshd_config'])
+                      '/etc/ssh/sshd_config',])
 
       return unless host
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'beaker'
 
 begin
@@ -5,17 +7,17 @@ begin
   require 'simplecov-console'
   require 'codecov'
 rescue LoadError
+  # Do nothing if no required gem installed
 else
   SimpleCov.start do
     track_files 'lib/**/*.rb'
 
     add_filter '/spec'
-
-    enable_coverage :branch
-
     # do not track vendored files
     add_filter '/vendor'
     add_filter '/.vendor'
+
+    enable_coverage :branch
   end
 
   SimpleCov.formatters = [
@@ -24,7 +26,7 @@ else
   ]
 end
 
-Dir.glob(Dir.pwd + '/lib/beaker/hypervisor/*.rb') {|file| require file}
+Dir['./lib/beaker/hypervisor/*.rb'].sort.each { |file| require file }
 
 # setup & require beaker's spec_helper.rb
 beaker_gem_spec = Gem::Specification.find_by_name('beaker')


### PR DESCRIPTION
This PR includes rubocop-inspired fixes. Though there was few unrelated changes:
- `Gemfile.local` was removed
- `vendor` directory was added to the `.gitignore`
- `.editorconfig` added (mostly to keep trailing spaces and newlines under control)
- `bin/beaker-docker` was fixed (it seems it was never really working 🤔)
- `00_default_spec.rb` was rewritten in Beaker DSL (`beaker-rspec` was not really used there)