### PR TITLE
Deal with docker_cmd being an array and remove use of =~

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -328,13 +328,6 @@ Performance/RedundantSplitRegexpArgument:
   Exclude:
     - 'lib/beaker/hypervisor/docker.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Performance/RegexpMatch:
-  Exclude:
-    - 'Rakefile'
-    - 'lib/beaker/hypervisor/docker.rb'
-
 # Offense count: 8
 # Cop supports --auto-correct.
 Performance/StringInclude:

--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ namespace :docs do
     Dir.chdir( File.expand_path(File.dirname(__FILE__)) )
     output = `bundle exec yard doc`
     puts output
-    if output =~ /\[warn\]|\[error\]/
+    if /\[warn\]|\[error\]/.match?(output)
       fail "Errors/Warnings during yard documentation generation"
     end
     Dir.chdir( original_dir )

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -37,7 +37,7 @@ module Beaker
       ::Docker.logger = @logger
 
       # Find out what kind of remote instance we are talking against
-      if @docker_version['Version'] =~ /swarm/
+      if /swarm/.match?(@docker_version['Version'])
         @docker_type = 'swarm'
         unless ENV['DOCKER_REGISTRY']
           raise "Using Swarm with beaker requires a private registry. Please setup the private registry and set the 'DOCKER_REGISTRY' env var"
@@ -58,7 +58,7 @@ module Beaker
 
       # If the container is running ssh as its init process then this method
       # will cause issues.
-      if Array(host[:docker_cmd]).first =~ /sshd/
+      if /sshd/.match?(Array(host[:docker_cmd]).first)
         def host.ssh_service_restart
           self[:docker_container].exec(%w(kill -1 1))
         end

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -58,7 +58,7 @@ module Beaker
 
       # If the container is running ssh as its init process then this method
       # will cause issues.
-      if host[:docker_cmd] =~ /sshd/
+      if Array(host[:docker_cmd]).first =~ /sshd/
         def host.ssh_service_restart
           self[:docker_container].exec(%w(kill -1 1))
         end

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -688,7 +688,7 @@ module Beaker
               'platform' => platform,
               'image' => 'foobar',
             })
-            expect( dockerfile ).to be =~ /ENV container docker/
+            expect( dockerfile ).to match(/ENV container docker/)
           end
         end
 
@@ -705,7 +705,7 @@ module Beaker
               ]
             })
 
-            expect( dockerfile ).to be =~ /RUN special one\nRUN special two\nRUN special three/
+            expect( dockerfile ).to match(/RUN special one\nRUN special two\nRUN special three/)
           end
         end
 
@@ -722,7 +722,7 @@ module Beaker
               ]
             })
 
-            expect( dockerfile ).to be =~ /RUN special one\nRUN special two\nRUN special three/
+            expect( dockerfile ).to match(/RUN special one\nRUN special two\nRUN special three/)
           end
         end
 
@@ -735,7 +735,7 @@ module Beaker
               'docker_image_entrypoint' => '/bin/bash'
             })
 
-            expect( dockerfile ).to be =~ %r{ENTRYPOINT /bin/bash}
+            expect( dockerfile ).to match(%r{ENTRYPOINT /bin/bash})
           end
         end
 
@@ -746,7 +746,7 @@ module Beaker
             'image' => 'foobar',
           })
 
-          expect( dockerfile ).to be =~ /zypper -n in openssh/
+          expect( dockerfile ).to match(/zypper -n in openssh/)
         end
 
         (22..39).to_a.each do | fedora_release |
@@ -757,7 +757,7 @@ module Beaker
               'image' => 'foobar',
             })
 
-            expect( dockerfile ).to be =~ /dnf install -y sudo/
+            expect( dockerfile ).to match(/dnf install -y sudo/)
           end
         end
 


### PR DESCRIPTION
This is dropped in Ruby 3.2 and RuboCop also flags it as a potential performance improvement.