### PR TITLE
Allow fakefs 2.x

### DIFF
--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Testing dependencies
-  s.add_development_dependency 'fakefs', '~> 1.3'
+  s.add_development_dependency 'fakefs', '>= 1.3', '< 3.0'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.3'


### PR DESCRIPTION
We still need to allow version < 1.9 for Ruby < 2.7 support.