### PR TITLE
Remove Gemfile.local from git

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,6 @@ Naming/FileName:
   Description: Some files violates the snake_case convention
   Exclude:
     - 'lib/beaker-docker.rb'
-    - Gemfile.local
 
 # Style enforcements
 Style/TrailingCommaInArrayLiteral:

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-if File.exist? "#{__FILE__}.local"
-  eval(File.read("#{__FILE__}.local"), binding) # rubocop:disable Security/Eval
+group :acceptance_testing do
+  gem 'beaker-rspec'
 end
 
 group :coverage, optional: ENV['COVERAGE'] != 'yes' do

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-group :acceptance_testing do
-  gem 'beaker-rspec'
-end


### PR DESCRIPTION
A local file checked into git is contradictory. This merges the file into Gemfile.