### PR TITLE
Implement standalone host image tagging

### DIFF
--- a/bin/beaker-docker
+++ b/bin/beaker-docker
@@ -2,7 +2,43 @@
 # frozen_string_literal: true
 
 require 'rubygems' unless defined?(Gem)
-require 'beaker-docker'
+require 'beaker'
+require "beaker/hypervisor/docker"
+
+def build(hostspec)
+  ENV['BEAKER_HYPERVISOR'] = 'docker'
+  options = Beaker::Options::Parser.new.parse_args(['--hosts', hostspec])
+  logger = Beaker::Logger.new(options)
+
+  # add additional paths to the LOAD_PATH
+  options[:load_path].each do |path|
+    $LOAD_PATH << File.expand_path(path)
+  end
+  options[:helper].each do |helper|
+    require File.expand_path(helper)
+  end
+
+  # Simplified version of Beaker::NetworkManager
+  hostless_options = Beaker::Options::OptionsHash.new.merge(options.select { |k, _v| !k.to_s.include?('HOSTS') })
+
+  hosts = options['HOSTS'].map do |name, host_hash|
+    Beaker::Host.create(name, host_hash, hostless_options)
+  end
+
+  hypervisor = Beaker::Docker.new(hosts, options)
+  logger.notify 'Provisioning docker'
+
+  hosts.map do |host|
+    logger.notify "building #{host.name}"
+    image = hypervisor.get_container_image(host)
+
+    if host['tag']
+      hypervisor.tag_contaner_image(image, host['tag'])
+    else
+      logger.notify "Built #{host.name} with #{image.id}"
+    end
+  end
+end
 
 VERSION_STRING = <<'VER'
                                  _ .--.
@@ -25,6 +61,10 @@ VERSION_STRING = <<'VER'
                      '=='
 VER
 
-puts VERSION_STRING % BeakerDocker::VERSION
+if ARGV[0] == 'build'
+  build(ARGV[1])
+else
+  puts VERSION_STRING % BeakerDocker::VERSION
+end
 
 exit 0

--- a/bin/beaker-docker
+++ b/bin/beaker-docker
@@ -40,6 +40,36 @@ def build(hostspec)
   end
 end
 
+def dockerfile(hostspec, filename)
+  ENV['BEAKER_HYPERVISOR'] = 'docker'
+  options = Beaker::Options::Parser.new.parse_args(['--hosts', hostspec])
+  logger = Beaker::Logger.new(options)
+
+  # add additional paths to the LOAD_PATH
+  options[:load_path].each do |path|
+    $LOAD_PATH << File.expand_path(path)
+  end
+  options[:helper].each do |helper|
+    require File.expand_path(helper)
+  end
+
+  # Simplified version of Beaker::NetworkManager
+  hostless_options = Beaker::Options::OptionsHash.new.merge(options.select { |k, _v| !k.to_s.include?('HOSTS') })
+
+  hosts = options['HOSTS'].map do |name, host_hash|
+    Beaker::Host.create(name, host_hash, hostless_options)
+  end
+
+  if hosts.size != 1
+    logger.error "Found #{hosts.size} hosts, expected 1"
+    exit(1)
+  end
+
+  hypervisor = Beaker::Docker.new(hosts, options)
+  # TODO: private method
+  File.write(filename, hypervisor.send(:dockerfile_for, hosts.first))
+end
+
 VERSION_STRING = <<'VER'
                                  _ .--.
                                 ( `    )
@@ -61,8 +91,11 @@ VERSION_STRING = <<'VER'
                      '=='
 VER
 
-if ARGV[0] == 'build'
+case ARGV[0]
+when 'build'
   build(ARGV[1])
+when 'containerfile', 'dockerfile'
+  dockerfile(ARGV[1], ARGV[2] || 'Containerfile')
 else
   puts VERSION_STRING % BeakerDocker::VERSION
 end

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -124,6 +124,18 @@ module Beaker
       ::Docker::Image.build(dockerfile_for(host), { rm: true, buildargs: buildargs_for(host) })
     end
 
+    def tag_container_image(image, host_tag)
+      raise ValueError, 'No tag specified' unless host_tag
+
+      if host_tag.include?(':')
+        repo, tag = host_tag.split(':')
+        opts = { repo: repo, tag: tag }
+      else
+        opts = { repo: repo }
+      end
+      image.tag(opts)
+    end
+
     # Nested Docker scenarios
     def nested_docker?
       ENV['DOCKER_IN_DOCKER'] || ENV.fetch('WSLENV', nil)
@@ -208,7 +220,7 @@ module Beaker
 
         image = get_container_image(host)
 
-        image.tag({ repo: host['tag'] }) if host['tag']
+        tag_container_image(image, host['tag']) if host['tag']
 
         if @docker_type == 'swarm'
           image_name = "#{@registry}/beaker/#{image.id}"


### PR DESCRIPTION
This allows running:

```
beaker-docker build 'centos9-64{tag=beaker-hostgenerator:centos9-64}'
```

The spec is ran through beaker-hostgenerator.