### PR TITLE
Implement writing out a containerfile for a host

### DIFF
--- a/bin/beaker-docker
+++ b/bin/beaker-docker
@@ -2,7 +2,26 @@
 # frozen_string_literal: true
 
 require 'rubygems' unless defined?(Gem)
+require 'beaker'
 require 'beaker-docker'
+
+def dockerfile(hostspec, filename)
+  ENV['BEAKER_HYPERVISOR'] = 'docker'
+  options = Beaker::Options::Parser.new.parse_args(['--hosts', hostspec || '', '--no-provision'])
+  options[:logger] = Beaker::Logger.new(options)
+  network_manager = Beaker::NetworkManager.new(options, options[:logger])
+  network_manager.provision
+  hosts = network_manager.hosts
+
+  if hosts.size != 1
+    options[:logger].error "Found #{hosts.size} hosts, expected 1"
+    exit(1)
+  end
+
+  hypervisor = network_manager.hypervisors['docker']
+  # TODO: private method
+  File.write(filename, hypervisor.send(:dockerfile_for, hosts.first))
+end
 
 VERSION_STRING = <<'VER'
                                  _ .--.
@@ -25,6 +44,13 @@ VERSION_STRING = <<'VER'
                      '=='
 VER
 
-puts VERSION_STRING % BeakerDocker::VERSION
+case ARGV[0]
+when 'containerfile'
+  dockerfile(ARGV[1], ARGV[2] || 'Containerfile')
+when 'dockerfile'
+  dockerfile(ARGV[1], ARGV[2] || 'Dockerfile')
+else
+  puts VERSION_STRING % BeakerDocker::VERSION
+end
 
 exit 0


### PR DESCRIPTION
This allows running:

    beaker-docker containerfile centos9-64

The spec is ran through beaker-hostgenerator and then it writes to Containerfile. The filename can also be passed in as an additional argument.

This is an alternative to https://github.com/voxpupuli/beaker-docker/pull/124.