### PR TITLE
Add ContainerPodman class

### DIFF
--- a/lib/beaker/hypervisor/container.rb
+++ b/lib/beaker/hypervisor/container.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'beaker/hypervisor/docker'
+
+module Beaker
+  class Container < Beaker::Docker
+  end
+end

--- a/lib/beaker/hypervisor/container_podman.rb
+++ b/lib/beaker/hypervisor/container_podman.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'beaker/hypervisor/container'
+
+module Beaker
+  class ContainerPodman < Beaker::Container
+  end
+end


### PR DESCRIPTION
This allows us to set the beaker hypervisor not only to `docker`, but also to `docker_podman`. This enables us to implement podman specific patches (if we ever need to). But it also makes it easier for modules to specify if they want to use podman or docker. See https://github.com/voxpupuli/gha-puppet/pull/48 for reference.