### PR TITLE
Rakefile: Use rubocop tasks from voxpupuli-rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,16 +3,9 @@
 require 'rspec/core/rake_task'
 
 begin
-  require 'rubocop/rake_task'
+  require 'voxpupuli/rubocop/rake'
 rescue LoadError
-  # RuboCop is an optional group
-else
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    # These make the rubocop experience maybe slightly less terrible
-    task.options = ['--display-cop-names', '--display-style-guide', '--extra-details']
-    # Use Rubocop's Github Actions formatter if possible
-    task.formatters << 'github' if ENV['GITHUB_ACTIONS'] == 'true'
-  end
+  # the voxpupuli-rubocop gem is optional
 end
 
 namespace :test do


### PR DESCRIPTION
our metagem voxpupuli-rubocop defines the rake task, we don't need to do it on our own.