### PR TITLE
docker-api: depend on 2.3 or newer

### DIFF
--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'beaker', '>= 4', '< 7'
-  s.add_runtime_dependency 'docker-api', '~> 2.1'
+  s.add_runtime_dependency 'docker-api', '~> 2.3'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
 end


### PR DESCRIPTION
2.2 and older allowed latest excon releases. excon v0.111.0 introduced a frozen string that was incompatible with docker-api 2.2 and older. This was fixed in https://github.com/upserve/docker-api/pull/588. Bumping our dependency to docker-api 2.3 or newer ensures that we don't pull in broken versions by accident.