### PR TITLE
CI: Switch from EL7/8->Debian12/EL9

### DIFF
--- a/acceptance/config/nodes/hosts.yaml
+++ b/acceptance/config/nodes/hosts.yaml
@@ -1,9 +1,9 @@
 ---
 HOSTS:
-  centos8:
-    platform: el-8-x86_64
+  centos9:
+    platform: el-9-x86_64
     hypervisor: docker
-    image: quay.io/centos/centos:stream8
+    image: quay.io/centos/centos:stream9
     roles:
       - master
       - agent
@@ -12,14 +12,13 @@ HOSTS:
       - classifier
       - default
     docker_cmd: '["/sbin/init"]'
-  centos7:
-    platform: el-7-x86_64
+  debian12:
+    platform: debian-12-x86_64
     hypervisor: docker
-    image: centos:7
+    image: debian:12
     roles:
       - agent
-    docker_cmd: '/usr/sbin/sshd -D -E /var/log/sshd.log'
-    use_image_entrypoint: true
+    docker_cmd: '["/sbin/init"]'
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'beaker', '>= 4', '< 7'
-  s.add_runtime_dependency 'docker-api', '~> 2.1'
+  s.add_runtime_dependency 'docker-api', '~> 2.3'
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
 end


### PR DESCRIPTION
also contains https://github.com/voxpupuli/beaker-docker/pull/139

This is required because the old images are EoL and not working anymore.