### PR TITLE
Arch Linux: remove redundant system updates

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -392,8 +392,6 @@ module Beaker
         container.exec(%w[ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key])
         container.exec(%w[sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config])
       when /archlinux/
-        container.exec(%w[pacman --noconfirm -Sy archlinux-keyring])
-        container.exec(%w[pacman --noconfirm -Syu])
         container.exec(%w[pacman -S --noconfirm openssh])
         container.exec(%w[ssh-keygen -A])
         container.exec(%w[sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config])


### PR DESCRIPTION
beaker already does this:
https://github.com/voxpupuli/beaker/blob/8bcd67c3216b99a9d8a88764c1d377702a1349c1/lib/beaker/host/unix/pkg.rb#L73C7-L80