### PR TITLE
add ContainerDocker and ContainerSwarm

### DIFF
--- a/lib/beaker/hypervisor/container_docker.rb
+++ b/lib/beaker/hypervisor/container_docker.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'beaker/hypervisor/container'
+
+module Beaker
+  class ContainerDocker < Beaker::Container
+  end
+end

--- a/lib/beaker/hypervisor/container_swarm.rb
+++ b/lib/beaker/hypervisor/container_swarm.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'beaker/hypervisor/container'
+
+module Beaker
+  class ContainerSwarm < Beaker::Container
+  end
+end


### PR DESCRIPTION
both are plain aliases for Container, which is an alias for Docker
(today), as that's where all the code lives
