### PR TITLE
Fix ssh connection routing under Podman: network naming and container detection

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -200,4 +200,11 @@ The tests should then run as normal from there.
 
 
 ### Docker-in-Docker (dind) ###
-If you are using docker in docker, set the environment variable DOCKER_IN_DOCKER=true. Beaker-docker will then not try to use the DOCKER_HOST address for the ssh connection to the containers.
+If beaker itself runs inside a container (for example in a CI job) and the test
+containers are created as siblings on the same host, set the environment
+variable DOCKER_IN_DOCKER=true. By default beaker-docker connects via the
+DOCKER_HOST address or a port published on 127.0.0.1, both of which point at
+the wrong place from inside a sibling container. With DOCKER_IN_DOCKER=true it
+connects to each test container's network IP directly instead; make sure the
+beaker container is attached to the same network as the test containers. This
+works with podman as well as docker.

--- a/docker.md
+++ b/docker.md
@@ -201,10 +201,16 @@ The tests should then run as normal from there.
 
 ### Docker-in-Docker (dind) ###
 If beaker itself runs inside a container (for example in a CI job) and the test
-containers are created as siblings on the same host, set the environment
-variable DOCKER_IN_DOCKER=true. By default beaker-docker connects via the
-DOCKER_HOST address or a port published on 127.0.0.1, both of which point at
-the wrong place from inside a sibling container. With DOCKER_IN_DOCKER=true it
-connects to each test container's network IP directly instead; make sure the
-beaker container is attached to the same network as the test containers. This
-works with podman as well as docker.
+containers are created as siblings on the same host, beaker-docker detects
+this automatically (via `/.dockerenv` on docker or `/run/.containerenv` on
+podman) and connects through the bridge gateway and each test container's
+published ssh port. No configuration is needed as long as the published port
+is reachable via the gateway address.
+
+If gateway routing does not work in your environment (ssh port not published
+to the host, or a firewall blocking traffic to the gateway), set the
+environment variable DOCKER_IN_DOCKER=true. Beaker-docker then ignores the
+DOCKER_HOST address and published ports, and connects to each test
+container's network IP directly; make sure the beaker container is attached
+to the same network as the test containers. This works with podman as well
+as docker, and is also enabled automatically under WSL.

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -648,9 +648,9 @@ module Beaker
       nil
     end
 
-    # return true if we are inside a docker container
+    # return true if we are inside a docker or podman container
     def in_container?
-      File.file?('/.dockerenv')
+      File.file?('/.dockerenv') || File.file?('/run/.containerenv')
     end
   end
 end

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -153,7 +153,7 @@ module Beaker
         gw = network_settings['Gateway']
 
         # also handle scenarios where network_settings['Gateway'] is not set (e.g. docker-ce >= v29)
-        gw = network_settings['Networks'][host_config['NetworkMode']]['Gateway'] if gw.nil? || gw.empty?
+        gw = container_network(network_settings, host_config)['Gateway'] if gw.nil? || gw.empty?
 
         ip = gw unless gw.nil? || gw.empty?
       else
@@ -170,7 +170,7 @@ module Beaker
         unless ip && port
           ip = network_settings['IPAddress'] # podman
           # also handle scenarios where network_settings['IPAddress'] is not set (e.g. docker-ce >= v29)
-          ip = network_settings['Networks'][host_config['NetworkMode']]['IPAddress'] if ip.nil? || ip.empty?
+          ip = container_network(network_settings, host_config)['IPAddress'] if ip.nil? || ip.empty?
           port = (ip && !ip.empty?) ? 22 : nil
         end
 
@@ -363,7 +363,7 @@ module Beaker
         host_config = container.json['HostConfig']
         vm_ip = container.json['NetworkSettings']['IPAddress']
         # handle scenarios where network_settings['IPAddress'] is not set (e.g. docker-ce >= v29)
-        vm_ip = container.json['NetworkSettings']['Networks'][host_config['NetworkMode']]['IPAddress'] if vm_ip.nil? || vm_ip.empty?
+        vm_ip = container_network(container.json['NetworkSettings'], host_config)['IPAddress'] if vm_ip.nil? || vm_ip.empty?
         host['vm_ip'] = vm_ip.to_s
 
         def host.reboot
@@ -462,6 +462,15 @@ module Beaker
     end
 
     private
+
+    # Look up the network a container is attached to. Podman's Docker-compatible
+    # API reports HostConfig.NetworkMode as 'bridge' but keys
+    # NetworkSettings.Networks by the actual network name, so fall back to the
+    # first attached network when the NetworkMode key is missing.
+    def container_network(network_settings, host_config)
+      networks = network_settings['Networks'] || {}
+      networks[host_config['NetworkMode']] || networks.values.first || {}
+    end
 
     def root_password
       'root'

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -686,6 +686,17 @@ module Beaker
                   expect(hosts[0]['port']).to eq 8022
                 end
               end
+
+              it 'connects to gateway ip inside a podman container' do
+                FakeFS do
+                  FileUtils.mkdir_p('/run')
+                  FileUtils.touch('/run/.containerenv')
+                  docker.provision
+
+                  expect(hosts[0]['ip']).to eq '192.0.2.254'
+                  expect(hosts[0]['port']).to eq 8022
+                end
+              end
             end
           end
 

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -739,6 +739,51 @@ module Beaker
               end
             end
           end
+
+          context 'when using podman where Networks is keyed by network name instead of NetworkMode' do
+            let(:container_config) do
+              {
+                'HostConfig' => {
+                  'NetworkMode' => 'bridge',
+                },
+                'NetworkSettings' => {
+                  'Ports' => {
+                    '22/tcp' => [
+                      {
+                        'HostIp' => '0.0.0.0',
+                        'HostPort' => 8022,
+                      },
+                    ],
+                  },
+                  'Networks' => {
+                    'podman' => {
+                      'Gateway' => '192.0.2.254',
+                      'IPAddress' => '192.0.2.10',
+                    },
+                  },
+                },
+              }
+            end
+
+            it 'falls back to the first network for the container IP' do
+              ENV['DOCKER_IN_DOCKER'] = 'true'
+              docker.provision
+
+              expect(hosts[0]['ip']).to eq '192.0.2.10'
+              expect(hosts[0]['port']).to eq 22
+              expect(hosts[0]['vm_ip']).to eq '192.0.2.10'
+            end
+
+            it 'still connects via the published port from the host' do
+              ENV['DOCKER_IN_DOCKER'] = nil
+              ENV['DOCKER_HOST'] = nil
+              docker.provision
+
+              expect(hosts[0]['ip']).to eq '127.0.0.1'
+              expect(hosts[0]['port']).to eq 8022
+              expect(hosts[0]['vm_ip']).to eq '192.0.2.10'
+            end
+          end
         end
 
         it 'generates a new /etc/hosts file referencing each host' do


### PR DESCRIPTION
Fixes #192
Fixes #193

Two commits, in dependency order. Together they make ssh connection routing work when beaker runs under Podman, in particular the sibling-container setup (beaker itself in a container, SUT containers next to it on a shared network).

**Commit 1: Handle Podman's network naming in NetworkSettings lookups (#192).**
Podman's Docker-compatible API reports `HostConfig.NetworkMode` as `'bridge'` but keys `NetworkSettings.Networks` by the actual network name (e.g. `'podman'`), so the three `Networks[NetworkMode]` fallback lookups (added in #180/#182 for docker-ce >= v29) raised `NoMethodError` whenever the top-level `IPAddress`/`Gateway` was empty. The lookups now go through a `container_network` helper that falls back to the first attached network. Also expands the dind section in `docker.md`.

**Commit 2: Detect Podman containers in `in_container?` (#193).**
Podman marks containers with `/run/.containerenv`, not `/.dockerenv`, so the existing gateway connection path never triggered under Podman and beaker fell through to `127.0.0.1`. Check both marker files. This commit sits on top of the first because the gateway path uses the same `Networks` lookup and would crash without it. Behavioral note: beaker running inside a Podman container now gets the gateway IP instead of `127.0.0.1`, the behavior Docker containers already get, so this is parity rather than a new code path.

**Verification**

- Unit specs: each commit's specs fail on the unpatched code and pass with it (`bundle exec rspec spec/beaker/hypervisor/docker_spec.rb`: 95 examples, 0 failures; rubocop clean).
- End to end on Podman 5.6.2 (rootful): a runner container with the podman socket mounted, `DOCKER_IN_DOCKER=true`, AlmaLinux 9 SUT: stock gem crashes as described in #192; with this branch beaker connects at the container's network IP on port 22 and the suite passes.
- End to end on Docker: the identical setup works with the stock gem and still works with this branch (Docker keys `Networks` as `'bridge'`, so the fallback never engages).

---

*Developed with the assistance of Claude Code (reviewed by a human).*



